### PR TITLE
fix result print out format

### DIFF
--- a/tests/integration_tests/CONV.py
+++ b/tests/integration_tests/CONV.py
@@ -47,6 +47,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/PSRChain_declustered.py
+++ b/tests/integration_tests/PSRChain_declustered.py
@@ -31,6 +31,8 @@
 from pathlib import Path
 import time
 
+import numpy as np
+
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core import Color
 from ansys.chemkin.core.inlet import (
@@ -52,6 +54,9 @@ ck.set_verbose(True)
 # interactive = False: save plot as a PNG file
 global interactive
 interactive = True
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 #####################################
 # Create a chemistry set

--- a/tests/integration_tests/PSRChain_network.py
+++ b/tests/integration_tests/PSRChain_network.py
@@ -29,6 +29,8 @@
 from pathlib import Path
 import time
 
+import numpy as np
+
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core import Color
 from ansys.chemkin.core.hybridreactornetwork import ReactorNetwork as Ern
@@ -46,6 +48,9 @@ current_dir = str(Path.cwd())
 logger.debug("working directory: " + current_dir)
 # set verbose mode
 ck.set_verbose(True)
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 #####################################
 # Create a chemistry set

--- a/tests/integration_tests/PSRgas.py
+++ b/tests/integration_tests/PSRgas.py
@@ -48,6 +48,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data" / "ModelFuelLibrary" / "Skeletal"
 mechanism_dir = data_dir

--- a/tests/integration_tests/PSRnetwork.py
+++ b/tests/integration_tests/PSRnetwork.py
@@ -54,6 +54,9 @@ ck.set_verbose(True)
 global interactive
 interactive = True
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 #####################################
 # Create a chemistry set
 # ===================================

--- a/tests/integration_tests/PSRnetwork_coupled.py
+++ b/tests/integration_tests/PSRnetwork_coupled.py
@@ -52,6 +52,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/SiC_cvd.py
+++ b/tests/integration_tests/SiC_cvd.py
@@ -47,6 +47,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # Create a chemistry set
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 # find the location of this example py file

--- a/tests/integration_tests/ZND.py
+++ b/tests/integration_tests/ZND.py
@@ -46,6 +46,9 @@ logger.debug("working directory: " + current_dir)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data" / "ModelFuelLibrary" / "Skeletal"
 mechanism_dir = data_dir

--- a/tests/integration_tests/catalytic_combustion.py
+++ b/tests/integration_tests/catalytic_combustion.py
@@ -47,6 +47,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # Create the chemistry sets
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 # find the location of this example py file
@@ -67,7 +70,6 @@ mech_no_surface.thermfile = str(data_dir / "grimech30_thermo.dat")
 
 # preprocess the mechanism files.
 _ = mech_no_surface.preprocess()
-
 
 # Set up the lean premixed fuel-air stream
 # set the fuel composition and conditions

--- a/tests/integration_tests/closed_homogeneous__transient.py
+++ b/tests/integration_tests/closed_homogeneous__transient.py
@@ -47,6 +47,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/createmixture.py
+++ b/tests/integration_tests/createmixture.py
@@ -42,6 +42,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/detonation.py
+++ b/tests/integration_tests/detonation.py
@@ -41,6 +41,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/diffusionvelocity.py
+++ b/tests/integration_tests/diffusionvelocity.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import numpy as np
+
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core.logger import logger
 from ansys.chemkin.core.mixture import Mixture, species_diffusion_velocity
@@ -38,6 +40,9 @@ ck.set_verbose(True)
 # interactive = False: save plot as a PNG file
 global interactive
 interactive = False
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"

--- a/tests/integration_tests/dual_flame.py
+++ b/tests/integration_tests/dual_flame.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import time
 
 import matplotlib.pyplot as plt  # plotting
+import numpy as np
 
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core import Color
@@ -45,6 +46,9 @@ ck.set_verbose(True)
 # interactive = False: save plot as a PNG file
 global interactive
 interactive = False
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"

--- a/tests/integration_tests/equilibriumcomposition.py
+++ b/tests/integration_tests/equilibriumcomposition.py
@@ -41,6 +41,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/hcciengine.py
+++ b/tests/integration_tests/hcciengine.py
@@ -45,6 +45,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/heatingvalues.py
+++ b/tests/integration_tests/heatingvalues.py
@@ -38,6 +38,10 @@ logger.debug("working directory: " + current_dir)
 global data_dir
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 logger.debug("data directory: " + str(data_dir))
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set pressure & temperature condition
 thispressure = ck.P_ATM
 thistemperature = 298.15

--- a/tests/integration_tests/ignitiondelay.py
+++ b/tests/integration_tests/ignitiondelay.py
@@ -48,6 +48,9 @@ ck.set_verbose(False)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/incidentshock.py
+++ b/tests/integration_tests/incidentshock.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import time
 
 import matplotlib.pyplot as plt  # plotting
+import numpy as np
 
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core import Color
@@ -43,6 +44,9 @@ logger.debug("working directory: " + current_dir)
 # interactive = False: save plot as a PNG file
 global interactive
 interactive = False
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 # Create a new mechanism input file 'no_hot_air_chem.inp' that
 # contains the reactions to describe NO formation in heated air.

--- a/tests/integration_tests/jetstirredreactor.py
+++ b/tests/integration_tests/jetstirredreactor.py
@@ -48,6 +48,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data" / "ModelFuelLibrary" / "Skeletal"
 mechanism_dir = data_dir

--- a/tests/integration_tests/loadmechanism.py
+++ b/tests/integration_tests/loadmechanism.py
@@ -28,6 +28,8 @@
 
 from pathlib import Path
 
+import numpy as np
+
 # import PyChemkin packages
 import ansys.chemkin.core as ck
 from ansys.chemkin.core import Color
@@ -40,6 +42,8 @@ logger.debug("working directory: " + current_dir)
 # set PyChemkin verbose mode
 ck.set_verbose(True)
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 #####################################
 # Create a chemistry set

--- a/tests/integration_tests/methane_flamespeed_table.py
+++ b/tests/integration_tests/methane_flamespeed_table.py
@@ -49,6 +49,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/mixing_IEM.py
+++ b/tests/integration_tests/mixing_IEM.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import numpy as np
+
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core.logger import logger
 from ansys.chemkin.core.mixture import Mixture, mixing_by_exchange_with_the_mean
@@ -38,6 +40,9 @@ ck.set_verbose(True)
 # interactive = False: save plot as a PNG file
 global interactive
 interactive = False
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"

--- a/tests/integration_tests/mixturemixing.py
+++ b/tests/integration_tests/mixturemixing.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import numpy as np
+
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core.logger import logger
 
@@ -32,6 +34,10 @@ current_dir = str(Path.cwd())
 logger.debug("working directory: " + current_dir)
 # set verbose mode
 ck.set_verbose(True)
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/multi-inletPSR.py
+++ b/tests/integration_tests/multi-inletPSR.py
@@ -46,6 +46,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data" / "ModelFuelLibrary" / "Skeletal"
 mechanism_dir = data_dir

--- a/tests/integration_tests/multiple_materials.py
+++ b/tests/integration_tests/multiple_materials.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import numpy as np
+
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core.logger import logger
 
@@ -37,6 +39,10 @@ ck.set_verbose(True)
 # interactive = False: save plot as a PNG file
 global interactive
 interactive = False
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # Create a chemistry set with surface chemistry
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 # find the floder where this py example file is located
@@ -75,6 +81,7 @@ for s in m_symbols:
 
 # Display surface material phase and species information as well as
 # the surface reactions of the material.
+
 # list the commonly used properties of all surface materials of the Chemistry Set
 for n, name in enumerate(m_symbols):
     # get the surface Material object by its name
@@ -88,30 +95,30 @@ for n, name in enumerate(m_symbols):
     print("elemental compositions of surface species on the material:")
     if m.num_site_species > 0:
         for i, p in enumerate(m.site_species_names):
-            print(f"  site species {p}")
+            print(f"  site species {p.rstrip()}")
             k = m.site_species_map[p]
             for e, ele in enumerate(MySurfMech.element_symbols):
                 print(f"    element {ele} = {m.material_species_composition(e, k)}")
         h_site = m.get_site_species_h(temp=400.0)
-        for j, h in enumerate(h_site):
+        for k, h in enumerate(h_site):
             # local index among all site species of this material
             print(
-                f"  site species {j} {m.site_species_names[j]} "
+                f"  site species {k} {m.site_species_names[k]} "
                 f"H = {h / ck.ERGS_PER_JOULE} [J/mole]"
             )
     # list the elemental compositions of all bulk species of the material
     if m.num_bulk_species > 0:
         for i, p in enumerate(m.bulk_species_names):
-            print(f"  bulk species {p}")
+            print(f"  bulk species {p.rstrip()}")
             k = m.bulk_species_map[p]
             for e, ele in enumerate(MySurfMech.element_symbols):
                 print(f"    element {ele} = {m.material_species_composition(e, k)}")
         # also the specific heat capacity of the bulk species
         cp_bulk = m.get_bulk_species_cp(temp=450.0)
-        for j, c in enumerate(cp_bulk):
+        for k, c in enumerate(cp_bulk):
             # local index among all bulk species of this material
             print(
-                f"  bulk species {j} {m.bulk_species_names[j]} "
+                f"  bulk species {k} {m.bulk_species_names[k]} "
                 f"Cp = {c / ck.ERGS_PER_JOULE} [J/mole-K]"
             )
     # get all phase names of the Chemistry Set, the "Gas" phase is always included

--- a/tests/integration_tests/multiplemechanisms.py
+++ b/tests/integration_tests/multiplemechanisms.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import numpy as np
+
 import ansys.chemkin.core as ck  # Chemkin
 from ansys.chemkin.core import Color
 from ansys.chemkin.core.logger import logger
@@ -33,6 +35,10 @@ current_dir = str(Path.cwd())
 logger.debug("working directory: " + current_dir)
 # set verbose mode
 ck.set_verbose(True)
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/multizone.py
+++ b/tests/integration_tests/multizone.py
@@ -45,6 +45,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/plugflow.py
+++ b/tests/integration_tests/plugflow.py
@@ -45,6 +45,9 @@ logger.debug("working directory: " + current_dir)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/premixedburnerflame.py
+++ b/tests/integration_tests/premixedburnerflame.py
@@ -49,6 +49,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/reactionrates.py
+++ b/tests/integration_tests/reactionrates.py
@@ -41,6 +41,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/sensitivity.py
+++ b/tests/integration_tests/sensitivity.py
@@ -48,6 +48,9 @@ ck.set_verbose(False)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/simple.py
+++ b/tests/integration_tests/simple.py
@@ -24,8 +24,13 @@
 
 from pathlib import Path
 
+import numpy as np
+
 import ansys.chemkin.core  # import PyChemkin
 from ansys.chemkin.core.logger import logger
+
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
 
 # create a Chemistry Set for GRI 3.0 mechanism in the data directory
 mechanism_dir = Path(ansys.chemkin.core.ansys_dir) / "reaction" / "data"

--- a/tests/integration_tests/sparkignitionengine.py
+++ b/tests/integration_tests/sparkignitionengine.py
@@ -46,6 +46,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/speciesproperties.py
+++ b/tests/integration_tests/speciesproperties.py
@@ -41,6 +41,9 @@ ck.set_verbose(True)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir

--- a/tests/integration_tests/vapor.py
+++ b/tests/integration_tests/vapor.py
@@ -45,6 +45,9 @@ logger.debug("working directory: " + current_dir)
 global interactive
 interactive = False
 
+# set numpy printing option
+np.set_printoptions(legacy="1.25")
+
 # set mechanism directory (the default Chemkin mechanism data directory)
 data_dir = Path(ck.ansys_dir) / "reaction" / "data"
 mechanism_dir = data_dir


### PR DESCRIPTION
use np.set_printoptions(legacy="1.25") to downgrade the numpy floating point value print out format to older version to prevent the inclusion of data type information.