### PR TITLE
improve the loading of the third-party shared objects

### DIFF
--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -35,11 +35,11 @@ Install PyChemkin
    ::
 
       pip install dist\ansys_chemkin-*.whl
-   
+
    Alternatively, you can install the package directly from the PyPI repository:
 
    ::
-   
+
       pip install ansys-chemkin-core
 
 2. Verify the installation.

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -35,16 +35,17 @@ Install PyChemkin
    ::
 
       pip install dist\ansys_chemkin-*.whl
-
+   
    Alternatively, you can install the package directly from the PyPI repository:
 
    ::
-
+   
       pip install ansys-chemkin-core
 
 2. Verify the installation.
 
-   Open the Python interpreter from the Windows command prompt and import the ``ansys-chemkin`` package:
+   Open the Python interpreter from the Windows command prompt and import the
+   ``ansys-chemkin-core`` package:
 
    ::
 
@@ -55,6 +56,7 @@ Install PyChemkin
    ::
 
       Chemkin version number = xxx
+      PyChemkin version number = x.x.x
 
    PyChemkin is probably not installed locally if Python displays nothing:
 
@@ -62,10 +64,17 @@ Install PyChemkin
 
       >>>
 
-   If Python displays the following statement, update the local Ansys Chemkin installation to 2025 R2 or later:
+   If Python displays the following statement, update the local Ansys Chemkin installation
+   to 2025 R2 or later:
 
    ::
 
       PyChemkin does not support Chemkin versions older than 2025 R2
 
-.. note:: You must have a valid Ansys license to run PyChemkin after installation.
+.. note::
+   1. You must have a valid Ansys license to run PyChemkin after installation.
+
+   2. PyChemkin will search for the latest version of the local Ansys Chemkin installation
+      and use it automatically. Use the ``PYCK_CHEMKIN_VER`` environment variable to specify
+      the desired local Ansys Chemkin installation. For example, set ``PYCK_CHEMKIN_VER="261"``
+      to force PyChemkin to use Ansys Chemkin 2026 R1.

--- a/src/ansys/chemkin/core/_platform_setup.py
+++ b/src/ansys/chemkin/core/_platform_setup.py
@@ -248,14 +248,12 @@ def __setup_windows(
                 lib_paths.append(str(lib_addition))
             else:
                 # >= 27R1
-                lib_addition = ansyshome / "tp" / "IntelCompiler" / "2023.1.0" / plat
-                lib_paths.append(str(lib_addition))
-                lib_addition = ansyshome / "tp" / "IntelMKL" / "2024.2.3" / plat
-                if not Path(lib_addition).is_dir():
-                    lib_addition = ansyshome / "tp" / "IntelMKL" / "2023.1.0" / plat
-                lib_paths.append(str(lib_addition))
-                lib_addition = ansyshome / "tp" / "zlib" / plat
-                lib_paths.append(str(lib_addition))
+                # configuration file for the 3rd-party dlls
+                third_party_config = ansyshome / "reaction" / ckbin / "bin"
+                third_party_paths: list[str] = set_3rd_party_dll_paths(
+                    str(ansyshome), str(third_party_config), plat
+                )
+                lib_paths.extend(third_party_paths)
     else:
         msg = [
             Color.RED,
@@ -270,6 +268,8 @@ def __setup_windows(
         for path in lib_paths:
             if Path(path).is_dir():
                 os.add_dll_directory(path)
+                # Append it to the existing system PATH variable
+                os.environ["PATH"] += os.pathsep + path
             else:
                 msg = [
                     Color.RED,
@@ -419,14 +419,13 @@ def __setup_linux(
         lib_paths.append(str(lib_addition))
     else:
         # >= 27R1
-        lib_addition = ansyshome / "tp" / "IntelCompiler" / "2023.1.0" / plat
-        lib_paths.append(str(lib_addition))
-        lib_addition = ansyshome / "tp" / "IntelMKL" / "2024.2.3" / plat
-        if not Path(lib_addition).is_dir():
-            lib_addition = ansyshome / "tp" / "IntelMKL" / "2023.1.0" / plat
-        lib_paths.append(str(lib_addition))
-        lib_addition = ansyshome / "tp" / "zlib" / plat
-        lib_paths.append(str(lib_addition))
+        # configuration file for the 3rd-party dlls
+        third_party_config = ansyshome / "reaction" / ckbin / "bin"
+        third_party_paths: list[str] = set_3rd_party_dll_paths(
+            str(ansyshome), str(third_party_config), plat
+        )
+        lib_paths.extend(third_party_paths)
+
     # set load shared object paths
     combined_path = ":".join(lib_paths)
     if "LD_LIBRARY_PATH" not in os.environ.keys():
@@ -435,6 +434,7 @@ def __setup_linux(
         os.environ["LD_LIBRARY_PATH"] = (
             os.environ["LD_LIBRARY_PATH"] + ":" + combined_path
         )
+        os.environ["PATH"] = os.environ["PATH"] + ":" + combined_path
 
     if "PATH" not in os.environ.keys():
         os.environ["PATH"] = combined_path
@@ -478,3 +478,72 @@ def find_valid_ansys_versions(min_ver: int = 251) -> list[int]:
         test_release -= 10
 
     return valid_versions
+
+
+def set_3rd_party_dll_paths(
+    ansys_folder: str, data_folder: str, lib_platform: str
+) -> list[str]:
+    """Set up the shared third-party dll paths.
+
+    Parameters
+    ----------
+    ansys_folder: str, required
+        location of the ANSYS installation folder.
+    data_folder: str, required
+        location of the text file containing the shared third-party dll paths.
+    lib_platform: str, required
+        platform label for the shared third-party dlls (e.g., "winx64").
+
+    Returns
+    -------
+    third_party_paths: list[str]
+        list of the shared third-party dll paths.
+
+    """
+    third_party_paths: list[str] = []
+    third_party_file = Path(data_folder) / "third-party_path_config.txt"
+    if not Path(third_party_file).is_file():
+        msg = [
+            Color.RED,
+            "Cannot find the third-party dll information file:\n",
+            str(third_party_file),
+            Color.END,
+        ]
+        this_msg = Color.SPACE.join(msg)
+        logger.critical(this_msg)
+        exit()
+    else:
+        line_error = False
+        with Path(third_party_file).open("r") as f:
+            for line in f:
+                if line.startswith("tp/"):
+                    parts = line.strip().split("/")
+                    if len(parts) == 4:
+                        lib_dir, lib_name, lib_version = (
+                            parts[0],
+                            parts[1],
+                            parts[2],
+                        )
+                        lib_addition = (
+                            Path(ansys_folder)
+                            / lib_dir
+                            / lib_name
+                            / lib_version
+                            / lib_platform
+                        )
+
+                        print(f"Adding third-party library path: {str(lib_addition)}")
+                        third_party_paths.append(str(lib_addition))
+                    else:
+                        msg = [
+                            Color.RED,
+                            "Invalid line in third-party dll information file:\n",
+                            line.strip(),
+                            Color.END,
+                        ]
+                        this_msg = Color.SPACE.join(msg)
+                        logger.critical(this_msg)
+                        line_error = True
+        if line_error:
+            exit()
+    return third_party_paths

--- a/src/ansys/chemkin/core/chemistry.py
+++ b/src/ansys/chemkin/core/chemistry.py
@@ -212,7 +212,8 @@ def done():
     # if check_jupyter_notebook():
     # running in Jupyter environment
     # requires addition steps
-    # _ = ck_wrapper.chemkin.KINExit()
+    if chemkin_version() >= 271:
+        _ = ck_wrapper.chemkin.KINExit()
 
     # clean up
     global _active_chemistry_set

--- a/src/ansys/chemkin/core/chemkin_wrapper.py
+++ b/src/ansys/chemkin/core/chemkin_wrapper.py
@@ -69,8 +69,22 @@ this_msg = Color.SPACE.join(msg)
 logger.debug(this_msg)
 # find all the valid Ansys versions installed on the local machine
 _valid_versions = find_valid_ansys_versions(_min_version)
-# uncomment the following line to force pychemkin to use a specific Ansys version
-# _valid_versions = [261]
+# check the environment variable "PYCK_CHEMKIN_VER"
+# if a specific Ansys version is requested
+_requested_ver = int(os.getenv("PYCK_CHEMKIN_VER", "0"))
+if _requested_ver in _valid_versions:
+    _valid_versions = [_requested_ver]
+else:
+    if _requested_ver != 0:
+        msg = [
+            Color.RED,
+            "requested Ansys version not found or not valid:",
+            str(_requested_ver),
+            Color.END,
+        ]
+        this_msg = Color.SPACE.join(msg)
+        logger.critical(this_msg)
+        exit()
 # check os platform
 if platform.system() == "Windows":
     # set pychemkin configuration for Windows
@@ -201,6 +215,17 @@ else:
         ]
         this_msg = Color.SPACE.join(msg)
         logger.critical(this_msg)
+        intel_link = "https://www.intel.com/content/www/us/en/developer/articles/tool"
+        intel_link += "/compilers-redistributable-libraries-by-version.html"
+        msg = [
+            Color.YELLOW,
+            "For Intel compiler runtime libraries related issues,",
+            "please install Intel® oneAPI DPC++/C++",
+            "and Fortran Compilers Runtime Libraries",
+            "at the link below:\n",
+            intel_link,
+            Color.END,
+        ]
         if platform.system() == "Linux":
             msg = [
                 Color.YELLOW,


### PR DESCRIPTION
1. make the third-party paths set up independent of the Ansys release by reading the third-party shared object paths from a configuration file in the Chemkin bin directory.
2. enable the use of a specific Ansys Chemkin version by setting the value of a system environment variable.
3. update getting-started document to reflect the new setup option.