### PR TITLE
Feat/premixed skip autoignition check

### DIFF
--- a/examples/premixed_flame/flamespeed.py
+++ b/examples/premixed_flame/flamespeed.py
@@ -166,7 +166,7 @@ premixed.pressure = fuel.pressure
 # set inlet/unburnt gas temperature [K]
 premixed.temperature = fuel.temperature
 # set estimated value of the flame speed [cm/sec]
-premixed.velocity = 65.0
+premixed.velocity = 80.0
 
 ##################################################
 # Instantiate the laminar speed calculator
@@ -287,6 +287,10 @@ flamespeedcalculator.set_species_floor(-1.0e-4)
 flamespeedcalculator.skip_fix_t_solution(mode=True)
 # reduce the Jacobian age during the pseudo time stepping phase
 flamespeedcalculator.set_pseudo_jacobian_age(10)
+
+# turn ON/OFF auto ignition check (optional)
+if ck.chemkin_version() >= 271:
+    flamespeedcalculator.set_auto_ignition_check(check=False)
 
 ####################################
 # Run the premixed flame calculation

--- a/src/ansys/chemkin/core/chemkin_wrapper.py
+++ b/src/ansys/chemkin/core/chemkin_wrapper.py
@@ -274,8 +274,9 @@ chemkin.KINInitialize.argtypes = [
 chemkin.KINFinish.restype = None
 chemkin.KINFinish.argtypes = []
 # (2027 R1 feature)
-# chemkin.KINExit.restype = ctypes.c_int
-# chemkin.KINExit.argtypes = []
+if _ansys_ver >= 271:
+    chemkin.KINExit.restype = ctypes.c_int
+    chemkin.KINExit.argtypes = []
 chemkin.KINUpdateChemistrySet.restype = ctypes.c_int
 chemkin.KINUpdateChemistrySet.argtypes = [
     ctypes.POINTER(ctypes.c_int),
@@ -1067,6 +1068,12 @@ chemkin.KINPremix_GetFlameMassFlux.restype = ctypes.c_int
 chemkin.KINPremix_GetFlameMassFlux.argtypes = [
     ctypes.POINTER(ctypes.c_double),
 ]
+# (2027 R1 feature)
+if _ansys_ver >= 271:
+    chemkin.KINPremix_SetAutoIgnitionCheck.restype = ctypes.c_int
+    chemkin.KINPremix_SetAutoIgnitionCheck.argtypes = [
+        ctypes.POINTER(ctypes.c_int),
+    ]
 
 # Oppdif interfaces
 chemkin.KINOppdif_SetInlet.restype = ctypes.c_int

--- a/src/ansys/chemkin/core/premixedflames/premixedflame.py
+++ b/src/ansys/chemkin/core/premixedflames/premixedflame.py
@@ -221,6 +221,37 @@ class PremixedFlame(Flame):
         ierr = numblines - npoints
         return ierr
 
+    def set_auto_ignition_check(self, check: bool = False):
+        """Set the auto-ignition check mode."""
+        """
+        Set the auto-ignition check mode for the premixed flame model.
+
+        Parameters
+        ----------
+            check: boolean {True, False}
+                False: no auto-ignition check
+                True: check auto-ignition
+
+        """
+        # set the auto-ignition check mode
+        this_mode = c_int(1)
+        if check:
+            this_mode = c_int(1)
+        else:
+            this_mode = c_int(0)
+        ierr = chemkin_wrapper.chemkin.KINPremix_SetAutoIgnitionCheck(this_mode)
+        if ierr != 0:
+            msg = [
+                Color.PURPLE,
+                "failed to set the auto-ignition check mode,",
+                "error code =",
+                str(ierr),
+                Color.END,
+            ]
+            this_msg = Color.SPACE.join(msg)
+            logger.error(this_msg)
+            exit()
+
     def __run_model(self) -> int:
         """Run the reactor model after the keywords are processed."""
         """


### PR DESCRIPTION
feat: new API to switch ON/OFF the auto-ignition check of the premixed flame model. 
separate the API interfaces that are available only in Chemkin v271
update the flamespeed example to include API to turn off the auto-ignition check.