### PR TITLE
Update artifacts.rst

### DIFF
--- a/doc/source/artifacts.rst
+++ b/doc/source/artifacts.rst
@@ -2,6 +2,4 @@ Artifacts
 =========
 
 Download the latest version of the artifacts from the
-[`release page`_].
-
-.. _release page: https://pypi.org/project/ansys-chemkin-core/#files
+release page: \https://pypi.org/project/ansys-chemkin-core/#files


### PR DESCRIPTION
convert the hyperlink to the PyPI download page to plain text because Fastly (an internet service company) prevents the link to be verified by the Doc build check (by making the link appeared to be broken).